### PR TITLE
fix: result divider of multi programming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches: [ main, dev, feature/* ]
   pull_request:
+    types: [ opened, synchronize, reopened ]
     branches: [ main, dev, feature/* ]
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 on:
   push:
-    branches: [ main, dev, feature/* ]
+    branches: [ main, develop, feature/* ]
   pull_request:
     types: [ opened, synchronize, reopened ]
-    branches: [ main, dev, feature/* ]
+    branches: [ main, develop, feature/* ]
   workflow_dispatch:
 
 jobs:

--- a/circuit_combiner/src/circuit_combiner/circuit_combiner.py
+++ b/circuit_combiner/src/circuit_combiner/circuit_combiner.py
@@ -182,7 +182,7 @@ class CircuitCombiner(CircuitCombinerService):
                 # save combined_qubits_list
                 # the order of the combined_qubits_list is reversed for
                 # the convenience of the measurement and division
-                combined_qubits_list = [one_circuit.num_qubits, *combined_qubits_list]
+                combined_qubits_list = [one_circuit.num_clbits, *combined_qubits_list]
             combined_circuit_obj = qiskit.qasm3.dumps(combined_circuit.decompose())
         except Exception:
             self.logger.exception("Exception")

--- a/circuit_combiner/tests/test_circuit_combiner.py
+++ b/circuit_combiner/tests/test_circuit_combiner.py
@@ -79,7 +79,7 @@ def test_combine_circuits_positive_2circuits_clbits_qubits():
         input_list, max_qubits
     )
     assert status == 0
-    assert combined_qubits_list == [2, 2]
+    assert combined_qubits_list == [1, 2]
     assert combined_qasm == comb_circ_text
 
 
@@ -121,7 +121,7 @@ def test_combine_circuits_positive_3circuits():
         input_list, max_qubits
     )
     assert status == 0
-    assert combined_qubits_list == [3, 2, 59]
+    assert combined_qubits_list == [1, 1, 2]
     assert combined_qasm == comb_circ_text
 
 
@@ -162,7 +162,7 @@ def test_combine_circuits_positive_3circuits_nochange_by_deviceinfo_in_maxcubits
         input_list, max_qubits
     )
     assert status == 0
-    assert combined_qubits_list == [3, 2, 59]
+    assert combined_qubits_list == [1, 1, 2]
     assert combined_qasm == comb_circ_text
 
 
@@ -379,7 +379,7 @@ def test_circuit_combiner_positive():
     comb_circ_text = qiskit.qasm3.dumps(comb_circ.decompose())
     assert response.combined_status == 0
     assert response.combined_qasm == comb_circ_text
-    assert response.combined_qubits_list == [1, 2]
+    assert response.combined_qubits_list == [0, 0]
 
 
 def test_circuit_combiner_negative_qasm_json_str_anomaly():

--- a/coreapp/multiprog/manual/resultdivider/result_divider.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider.go
@@ -3,11 +3,45 @@ package multiprog
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/oqtopus-team/oqtopus-engine/coreapp/core"
 	"go.uber.org/zap"
 )
+
+func fillMissingDigits(inputPhysicalBitString string, physicalQubitList []int) ([]string, error) {
+	// Fill in the missing digits of the physical qubit
+	// ex) When inputPhysicalBitString: "111" and virtualPhysicalMapping: {0: 0, 1: 2, 2: 4}, physical qubit 1 and 3 are missing.
+	//	   Then fill the missing physical qubit with 0, filledPhysicalBitString: "10101"
+
+	if len(physicalQubitList) != len(inputPhysicalBitString) {
+		return nil, fmt.Errorf("The length of the physical qubit list %d is not equal to the length of the input bit string %d",
+			len(physicalQubitList), len(inputPhysicalBitString))
+	}
+
+	// get the maximum physical qubit number
+	maxPhysical := 0
+	for _, physical := range physicalQubitList {
+		if physical > maxPhysical {
+			maxPhysical = physical
+		}
+	}
+
+	filledPhysicalBitMap := make([]string, maxPhysical+1)
+	cursor := len(inputPhysicalBitString) - 1
+	for i := 0; i <= maxPhysical; i++ {
+		if slices.Contains(physicalQubitList, i) {
+			// copy the bit string from the input
+			filledPhysicalBitMap[maxPhysical-i] = string(inputPhysicalBitString[cursor])
+			cursor--
+		} else {
+			// fill with 0 if the physical qubit is missing
+			filledPhysicalBitMap[maxPhysical-i] = "0"
+		}
+	}
+	return filledPhysicalBitMap, nil
+}
 
 func swapVirtualPhysical(counts core.Counts, virtualPhysicalMappingMap core.VirtualPhysicalMappingMap) (core.Counts, error) {
 	if len(virtualPhysicalMappingMap) == 0 {
@@ -17,21 +51,39 @@ func swapVirtualPhysical(counts core.Counts, virtualPhysicalMappingMap core.Virt
 	var result core.Counts = core.Counts{}
 	n_qubits := len(virtualPhysicalMappingMap)
 
+	physicalQubitList := []int{}
+	for _, physical := range virtualPhysicalMappingMap {
+		physicalQubitList = append(physicalQubitList, int(physical))
+	}
+
 	for inputPhysicalBitString, count := range counts {
-		length := len(inputPhysicalBitString)
-		if length != n_qubits {
+		virtualQubits := len(inputPhysicalBitString)
+		if virtualQubits != n_qubits {
 			return counts, errors.New("bit string length of the counts is not equal to the length of virtualPhysicalMapping")
 		}
+		// Fill in the missing digits of the physical qubit to make the next proccess easier
+		filledPhysicalBitMap, err := fillMissingDigits(inputPhysicalBitString, physicalQubitList)
+		if err != nil {
+			fmt.Errorf("failed to fill the missing digits of the physical qubit: %s", err)
+			return counts, err
+		}
+		physicalQubits := len(filledPhysicalBitMap)
+
 		// Swap the bits according to the virtualPhysicalMapping
-		swappedVirtualBitMap := make([]string, length)
+		swappedVirtualBitMap := make([]string, virtualQubits)
 		for virtual, physical := range virtualPhysicalMappingMap {
-			if int(physical) >= length || int(virtual) >= length {
+			if int(virtual) >= virtualQubits {
 				return counts,
-					fmt.Errorf("virtual or physical qubit number is out of range. virtual: %d, physical: %d, length: %d",
-						virtual, physical, length)
+					fmt.Errorf("virtual qubit number is out of range. virtual: %d, length: %d",
+						virtual, virtualQubits)
+			}
+			if int(physical) >= physicalQubits {
+				return counts,
+					fmt.Errorf("physical qubit number is out of range. physical: %d, length: %d",
+						physical, physicalQubits)
 			}
 			// relocate the physical qubit to the virtual qubit
-			swappedVirtualBitMap[length-int(virtual)-1] = inputPhysicalBitString[length-int(physical)-1 : length-int(physical)]
+			swappedVirtualBitMap[virtualQubits-int(virtual)-1] = filledPhysicalBitMap[physicalQubits-int(physical)-1]
 		}
 		result[strings.Join(swappedVirtualBitMap, "")] = count
 	}

--- a/coreapp/multiprog/manual/resultdivider/result_divider.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider.go
@@ -10,10 +10,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// Fill in the missing digits of the physical qubit.
+// ex) When inputPhysicalBitString: "111" and virtualPhysicalMapping: {0: 0, 1: 2, 2: 4}, physical qubit 1 and 3 are missing.
+// Then fill the missing physical qubit with 0, filledPhysicalBitString: "10101"
 func fillMissingDigits(inputPhysicalBitString string, physicalQubitList []int) ([]string, error) {
-	// Fill in the missing digits of the physical qubit
-	// ex) When inputPhysicalBitString: "111" and virtualPhysicalMapping: {0: 0, 1: 2, 2: 4}, physical qubit 1 and 3 are missing.
-	//	   Then fill the missing physical qubit with 0, filledPhysicalBitString: "10101"
 
 	if len(physicalQubitList) != len(inputPhysicalBitString) {
 		return nil, fmt.Errorf("The length of the physical qubit list %d is not equal to the length of the input bit string %d",
@@ -43,14 +43,49 @@ func fillMissingDigits(inputPhysicalBitString string, physicalQubitList []int) (
 	return filledPhysicalBitMap, nil
 }
 
+// If the length of digits in counts is less than the length of virtualPhysicalMapping,
+// extract the virtualPhysicalMapping based on the length of digits in the counts.
+// ex) When counts: {"00": 10, "11": 30} (length of digits = 2), virtualPhysicalMapping: {0: 0, 1: 2, 2: 3, 3: 1},
+// the virtual qubit greater than 1 is not measured and do not exist in classical bit.
+// Then the result virtualPhysicalMapping is {0: 0, 1: 2}.
+func extractVirtualPhysicalMapping(counts core.Counts, virtualPhysicalMapping core.VirtualPhysicalMappingMap) core.VirtualPhysicalMappingMap {
+	n_cbits := func() int {
+		for k := range counts {
+			return len(k)
+		}
+		return 0
+	}()
+
+	if n_cbits < len(virtualPhysicalMapping) {
+		// extract the pairs from virtualPhysicalMapping whose virtual qubit number is smaller than the number of classical bits.
+		result := core.VirtualPhysicalMappingMap{}
+		for virtual, physical := range virtualPhysicalMapping {
+			if virtual < uint32(n_cbits) {
+				// virtual qubit number is smaller than the number of classical bits.
+				result[virtual] = physical
+			}
+		}
+		return result
+	} else {
+		return virtualPhysicalMapping
+	}
+}
+
+// Swap the bits according to the virtualPhysicalMapping because there are cases where the physical and virtual qubits are swapped in transpiler.
+// The bit string of input counts is sorted based on the physical qubits, so the bits should be swapped to the virtual qubits.
+// ex) When counts: {"010": 10, "101": 30}, virtualPhysicalMapping: {0: 1, 1: 0, 2:2},
+// the result of this function is {"001": 10, "110": 30}
 func swapVirtualPhysical(counts core.Counts, virtualPhysicalMappingMap core.VirtualPhysicalMappingMap) (core.Counts, error) {
 	if len(virtualPhysicalMappingMap) == 0 {
 		zap.L().Info("No virtualPhysicalMapping is given, so the counts are not swapped")
 		return counts, nil
 	}
 	var result core.Counts = core.Counts{}
-	n_qubits := len(virtualPhysicalMappingMap)
 
+	// Step 1. Preparation: Waste the virtualPhysicalMapping that is not measured if neccessary.
+	virtualPhysicalMappingMap = extractVirtualPhysicalMapping(counts, virtualPhysicalMappingMap)
+
+	// get the physical qubit list
 	physicalQubitList := []int{}
 	for _, physical := range virtualPhysicalMappingMap {
 		physicalQubitList = append(physicalQubitList, int(physical))
@@ -58,10 +93,7 @@ func swapVirtualPhysical(counts core.Counts, virtualPhysicalMappingMap core.Virt
 
 	for inputPhysicalBitString, count := range counts {
 		virtualQubits := len(inputPhysicalBitString)
-		if virtualQubits != n_qubits {
-			return counts, errors.New("bit string length of the counts is not equal to the length of virtualPhysicalMapping")
-		}
-		// Fill in the missing digits of the physical qubit to make the next proccess easier
+		// Step 2. Preparation: Fill in the missing digits of the physical qubit to make the next proccess easier
 		filledPhysicalBitMap, err := fillMissingDigits(inputPhysicalBitString, physicalQubitList)
 		if err != nil {
 			fmt.Errorf("failed to fill the missing digits of the physical qubit: %s", err)
@@ -69,7 +101,7 @@ func swapVirtualPhysical(counts core.Counts, virtualPhysicalMappingMap core.Virt
 		}
 		physicalQubits := len(filledPhysicalBitMap)
 
-		// Swap the bits according to the virtualPhysicalMapping
+		// Step 3. Swap the bits according to the virtualPhysicalMapping
 		swappedVirtualBitMap := make([]string, virtualQubits)
 		for virtual, physical := range virtualPhysicalMappingMap {
 			if int(virtual) >= virtualQubits {

--- a/coreapp/multiprog/manual/resultdivider/result_divider.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider.go
@@ -152,9 +152,17 @@ func DivideResult(jd *core.JobData, combinedQubitsList []int32) (err error) {
 		err = errors.New("inconsistent qubit property")
 		return
 	}
+
+	// convert raw data to map
+	vpmMap, err := jd.Result.TranspilerInfo.VirtualPhysicalMappingRaw.ToMap()
+	if err != nil {
+		zap.L().Error(fmt.Sprintf("failed to convert VirtualPhysicalMappingRaw to VirtualPhysicalMappingMap: %s", err))
+		return
+	}
+
 	// Swap the bits according to the virtualPhysicalMapping
 	if jd.Result.TranspilerInfo != nil {
-		jd.Result.Counts, err = swapVirtualPhysical(jd.Result.Counts, jd.Result.TranspilerInfo.VirtualPhysicalMappingMap)
+		jd.Result.Counts, err = swapVirtualPhysical(jd.Result.Counts, vpmMap)
 		if err != nil {
 			return
 		}

--- a/coreapp/multiprog/manual/resultdivider/result_divider_test.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider_test.go
@@ -88,34 +88,34 @@ func Test_fillMissingDigits(t *testing.T) {
 
 func Test_extractVirtualPhysicalMapping(t *testing.T) {
 	type args struct {
-		counts                 core.Counts
-		virtualPhysicalMapping core.VirtualPhysicalMapping
+		counts                    core.Counts
+		virtualPhysicalMappingMap core.VirtualPhysicalMappingMap
 	}
 	tests := []struct {
 		name string
 		args args
-		want core.VirtualPhysicalMapping
+		want core.VirtualPhysicalMappingMap
 	}{
 		{
 			name: "no need to extract",
 			args: args{
-				counts:                 core.Counts{"00": 10, "11": 30},
-				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 1: 1},
+				counts:                    core.Counts{"00": 10, "11": 30},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1},
 			},
-			want: core.VirtualPhysicalMapping{0: 0, 1: 1},
+			want: core.VirtualPhysicalMappingMap{0: 0, 1: 1},
 		},
 		{
 			name: "need to extract",
 			args: args{
-				counts:                 core.Counts{"00": 10, "11": 30},
-				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 1: 2, 2: 3, 3: 1, 4: 4},
+				counts:                    core.Counts{"00": 10, "11": 30},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 2, 2: 3, 3: 1, 4: 4},
 			},
-			want: core.VirtualPhysicalMapping{0: 0, 1: 2},
+			want: core.VirtualPhysicalMappingMap{0: 0, 1: 2},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractVirtualPhysicalMapping(tt.args.counts, tt.args.virtualPhysicalMapping)
+			got := extractVirtualPhysicalMapping(tt.args.counts, tt.args.virtualPhysicalMappingMap)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -157,8 +157,8 @@ func Test_swapVirtualPhysical(t *testing.T) {
 		{
 			name: "2 qubits, VirtualPhysicalMapping is longer than classical bits, swap",
 			args: args{
-				counts:                 core.Counts{"00": 1, "01": 2, "10": 4, "11": 8}, // 2 cbits
-				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 5, 1: 4, 2: 0},   // 3 elements
+				counts:                    core.Counts{"00": 1, "01": 2, "10": 4, "11": 8},  // 2 cbits
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 5, 1: 4, 2: 0}, // 3 elements
 			},
 			want: core.Counts{"00": 1, "01": 4, "10": 2, "11": 8},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
@@ -275,8 +275,8 @@ func Test_swapVirtualPhysical(t *testing.T) {
 		{
 			name: "n_cbits is less than virtualPhysicalMapping",
 			args: args{
-				counts:                 core.Counts{"010": 1, "111": 2},
-				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 3: 3, 1: 2, 2: 1},
+				counts:                    core.Counts{"010": 1, "111": 2},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 3: 3, 1: 2, 2: 1},
 			},
 			want: core.Counts{"100": 1, "111": 2},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
@@ -286,8 +286,8 @@ func Test_swapVirtualPhysical(t *testing.T) {
 		{
 			name: "n_cbits is less than virtualPhysicalMapping, non-sequential pysical qubits",
 			args: args{
-				counts:                 core.Counts{"010": 1, "111": 2},
-				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 3: 2, 2: 3, 1: 5},
+				counts:                    core.Counts{"010": 1, "111": 2},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 3: 2, 2: 3, 1: 5},
 			},
 			want: core.Counts{"100": 1, "111": 2},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
@@ -486,7 +486,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{4},
 			},
@@ -519,7 +519,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -556,7 +556,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 1, 1: 2, 2: 3, 3: 0}}, // to be swapped
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 1, "1": 2, "2": 3, "3": 0}`)}, // to be swapped
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -592,7 +592,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMapping: core.VirtualPhysicalMapping{0: 1, 1: 2, 4: 4, 2: 3, 3: 0}}, // longer than the number of classical bits
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 1, "1": 2, "4": 4, "2": 3, "3": 0}`)}, // longer than the number of classical bits
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -628,7 +628,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 1, 1: 5, 2: 10, 3: 0}}, // to be swapped
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 1, "1": 5, "2": 10, "3": 0}`)}, // to be swapped
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -664,7 +664,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMapping: core.VirtualPhysicalMapping{0: 1, 1: 4, 4: 2, 2: 3, 3: 0}}, // longer and non-sequential
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 1, "1": 4, "4": 2, "2": 3, "3": 0}`)}, // longer and non-sequential
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -700,7 +700,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{3, 1, 1},
 			},
@@ -723,7 +723,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw{}},
 				}},
 				combinedQubitsList: []int32{},
 			},
@@ -738,7 +738,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{3, 2},
 			},
@@ -761,7 +761,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{},
 			},
@@ -784,7 +784,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2, 3: 3}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2, "3": 3}`)},
 				}},
 				combinedQubitsList: []int32{0, 0, 0},
 			},
@@ -807,7 +807,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{}},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw{}},
 				}},
 				combinedQubitsList: []int32{1, 2, 3},
 			},
@@ -822,7 +822,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 2}}, // short
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "1": 1, "2": 2}`)}, // short
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},
@@ -845,7 +845,7 @@ func TestDivideResult(t *testing.T) {
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
 					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
-					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 4: 1, 2: 2, 3: 3}}, // incorrect key
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingRaw: core.VirtualPhysicalMappingRaw(`{"0": 0, "4": 1, "2": 2, "3": 3}`)}, // incorrect key
 				}},
 				combinedQubitsList: []int32{3, 1},
 			},

--- a/coreapp/multiprog/manual/resultdivider/result_divider_test.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider_test.go
@@ -10,6 +10,71 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func Test_fillMissingDigits(t *testing.T) {
+	type args struct {
+		inputPhysicalBitString string
+		physicalQubitList      []int
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      []string
+		assertion assert.ErrorAssertionFunc
+	}{
+		{
+			name: "no missing digit",
+			args: args{
+				inputPhysicalBitString: "111",
+				physicalQubitList:      []int{0, 1, 2},
+			},
+			want: []string{"1", "1", "1"},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "missing 1 digit",
+			args: args{
+				inputPhysicalBitString: "111",
+				physicalQubitList:      []int{0, 1, 3},
+			},
+			want: []string{"1", "0", "1", "1"},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "missing 2 digits",
+			args: args{
+				inputPhysicalBitString: "111",
+				physicalQubitList:      []int{0, 2, 4},
+			},
+			want: []string{"1", "0", "1", "0", "1"},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "invalid physical qubits",
+			args: args{
+				inputPhysicalBitString: "111",
+				physicalQubitList:      []int{0, 2},
+			},
+			want: nil,
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, "The length of the physical qubit list 2 is not equal to the length of the input bit string 3")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fillMissingDigits(tt.args.inputPhysicalBitString, tt.args.physicalQubitList)
+			assert.Equal(t, tt.want, got)
+			tt.assertion(t, err)
+		})
+	}
+}
+
 func Test_swapVirtualPhysical(t *testing.T) {
 	type args struct {
 		counts                    core.Counts
@@ -92,6 +157,32 @@ func Test_swapVirtualPhysical(t *testing.T) {
 			},
 		},
 		{
+			name: "4 qubits, no swap, non-sequential pysical qubits",
+			args: args{
+				counts: core.Counts{"0000": 1, "0001": 2, "0010": 4, "0011": 8, "0100": 16, "0101": 32, "0110": 64, "0111": 128,
+					"1000": 256, "1001": 512, "1010": 1024, "1011": 2048, "1100": 4096, "1101": 8192, "1110": 16384, "1111": 32768},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 5, 1: 0, 2: 3, 3: 1},
+			},
+			want: core.Counts{"0000": 1, "0001": 256, "0010": 2, "0011": 512, "0100": 16, "0101": 4096, "0110": 32, "0111": 8192,
+				"1000": 4, "1001": 1024, "1010": 8, "1011": 2048, "1100": 64, "1101": 16384, "1110": 128, "1111": 32768},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "4 qubits, no swap, non-sequential pysical qubits",
+			args: args{
+				counts: core.Counts{"0000": 1, "0001": 2, "0010": 4, "0011": 8, "0100": 16, "0101": 32, "0110": 64, "0111": 128,
+					"1000": 256, "1001": 512, "1010": 1024, "1011": 2048, "1100": 4096, "1101": 8192, "1110": 16384, "1111": 32768},
+				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 5, 1: 0, 2: 3, 3: 1},
+			},
+			want: core.Counts{"0000": 1, "0001": 256, "0010": 2, "0011": 512, "0100": 16, "0101": 4096, "0110": 32, "0111": 8192,
+				"1000": 4, "1001": 1024, "1010": 8, "1011": 2048, "1100": 64, "1101": 16384, "1110": 128, "1111": 32768},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
 			name: "inconsistent qubits",
 			args: args{
 				counts:                    core.Counts{"010": 1, "111": 2},            // 3 qubits
@@ -132,18 +223,7 @@ func Test_swapVirtualPhysical(t *testing.T) {
 			},
 			want: core.Counts{"010": 1, "111": 2},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "virtual or physical qubit number is out of range. virtual: 3, physical: 0, length: 3")
-			},
-		},
-		{
-			name: "invalid physical qubit",
-			args: args{
-				counts:                    core.Counts{"010": 1, "111": 2},
-				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 0, 1: 1, 2: 3},
-			},
-			want: core.Counts{"010": 1, "111": 2},
-			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "virtual or physical qubit number is out of range. virtual: 2, physical: 3, length: 3")
+				return assert.EqualError(t, err, "virtual qubit number is out of range. virtual: 3, length: 3")
 			},
 		},
 	}
@@ -429,6 +509,42 @@ func TestDivideResult(t *testing.T) {
 			},
 		},
 		{
+			name: "Positive test - 2 circuits - swap virtual and physical qubits with non-sequential mapping",
+			args: args{
+				jd: &core.JobData{Result: &core.Result{
+					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 1, 1: 5, 2: 10, 3: 0}}, // to be swapped
+				}},
+				combinedQubitsList: []int32{3, 1},
+			},
+			wantCounts: core.Counts{
+				"0001": 16,
+				"0010": 2,
+				"0011": 32,
+				"0100": 4,
+				"1000": 1,
+				"1101": 64,
+				"1111": 8,
+			},
+			wantDividedCounts: core.DividedResult{
+				0: {
+					"0": 7,
+					"1": 120,
+				},
+				1: {
+					"000": 16,
+					"001": 34,
+					"010": 4,
+					"100": 1,
+					"110": 64,
+					"111": 8,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
 			name: "Negative test - exceeded member of combinedQubitsList",
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
@@ -593,7 +709,7 @@ func TestDivideResult(t *testing.T) {
 			},
 			wantDividedCounts: nil,
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "virtual or physical qubit number is out of range. virtual: 4, physical: 1, length: 4")
+				return assert.EqualError(t, err, "virtual qubit number is out of range. virtual: 4, length: 4")
 			},
 		},
 	}

--- a/coreapp/multiprog/manual/resultdivider/result_divider_test.go
+++ b/coreapp/multiprog/manual/resultdivider/result_divider_test.go
@@ -65,12 +65,58 @@ func Test_fillMissingDigits(t *testing.T) {
 				return assert.EqualError(t, err, "The length of the physical qubit list 2 is not equal to the length of the input bit string 3")
 			},
 		},
+		{
+			name: "invalid physical qubits (too much)",
+			args: args{
+				inputPhysicalBitString: "111",
+				physicalQubitList:      []int{0, 2, 3, 5},
+			},
+			want: nil,
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.EqualError(t, err, "The length of the physical qubit list 4 is not equal to the length of the input bit string 3")
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := fillMissingDigits(tt.args.inputPhysicalBitString, tt.args.physicalQubitList)
 			assert.Equal(t, tt.want, got)
 			tt.assertion(t, err)
+		})
+	}
+}
+
+func Test_extractVirtualPhysicalMapping(t *testing.T) {
+	type args struct {
+		counts                 core.Counts
+		virtualPhysicalMapping core.VirtualPhysicalMapping
+	}
+	tests := []struct {
+		name string
+		args args
+		want core.VirtualPhysicalMapping
+	}{
+		{
+			name: "no need to extract",
+			args: args{
+				counts:                 core.Counts{"00": 10, "11": 30},
+				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 1: 1},
+			},
+			want: core.VirtualPhysicalMapping{0: 0, 1: 1},
+		},
+		{
+			name: "need to extract",
+			args: args{
+				counts:                 core.Counts{"00": 10, "11": 30},
+				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 1: 2, 2: 3, 3: 1, 4: 4},
+			},
+			want: core.VirtualPhysicalMapping{0: 0, 1: 2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractVirtualPhysicalMapping(tt.args.counts, tt.args.virtualPhysicalMapping)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -102,6 +148,17 @@ func Test_swapVirtualPhysical(t *testing.T) {
 			args: args{
 				counts:                    core.Counts{"00": 1, "01": 2, "10": 4, "11": 8},
 				virtualPhysicalMappingMap: core.VirtualPhysicalMappingMap{0: 1, 1: 0},
+			},
+			want: core.Counts{"00": 1, "01": 4, "10": 2, "11": 8},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "2 qubits, VirtualPhysicalMapping is longer than classical bits, swap",
+			args: args{
+				counts:                 core.Counts{"00": 1, "01": 2, "10": 4, "11": 8}, // 2 cbits
+				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 5, 1: 4, 2: 0},   // 3 elements
 			},
 			want: core.Counts{"00": 1, "01": 4, "10": 2, "11": 8},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
@@ -190,7 +247,7 @@ func Test_swapVirtualPhysical(t *testing.T) {
 			},
 			want: core.Counts{"010": 1, "111": 2},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "bit string length of the counts is not equal to the length of virtualPhysicalMapping")
+				return assert.EqualError(t, err, "The length of the physical qubit list 2 is not equal to the length of the input bit string 3")
 			},
 		},
 		{
@@ -211,6 +268,28 @@ func Test_swapVirtualPhysical(t *testing.T) {
 				virtualPhysicalMappingMap: nil,
 			},
 			want: core.Counts{"010": 1, "111": 2},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "n_cbits is less than virtualPhysicalMapping",
+			args: args{
+				counts:                 core.Counts{"010": 1, "111": 2},
+				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 3: 3, 1: 2, 2: 1},
+			},
+			want: core.Counts{"100": 1, "111": 2},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "n_cbits is less than virtualPhysicalMapping, non-sequential pysical qubits",
+			args: args{
+				counts:                 core.Counts{"010": 1, "111": 2},
+				virtualPhysicalMapping: core.VirtualPhysicalMapping{0: 0, 3: 2, 2: 3, 1: 5},
+			},
+			want: core.Counts{"100": 1, "111": 2},
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
 				return assert.NoError(t, err)
 			},
@@ -509,6 +588,42 @@ func TestDivideResult(t *testing.T) {
 			},
 		},
 		{
+			name: "Positive test - 2 circuits - swap virtual and physical qubits with larger VirtualPhysicalMapping ",
+			args: args{
+				jd: &core.JobData{Result: &core.Result{
+					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMapping: core.VirtualPhysicalMapping{0: 1, 1: 2, 4: 4, 2: 3, 3: 0}}, // longer than the number of classical bits
+				}},
+				combinedQubitsList: []int32{3, 1},
+			},
+			wantCounts: core.Counts{
+				"0001": 16,
+				"0010": 2,
+				"0011": 32,
+				"0100": 4,
+				"1000": 1,
+				"1101": 64,
+				"1111": 8,
+			},
+			wantDividedCounts: core.DividedResult{
+				0: {
+					"0": 7,
+					"1": 120,
+				},
+				1: {
+					"000": 16,
+					"001": 34,
+					"010": 4,
+					"100": 1,
+					"110": 64,
+					"111": 8,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
 			name: "Positive test - 2 circuits - swap virtual and physical qubits with non-sequential mapping",
 			args: args{
 				jd: &core.JobData{Result: &core.Result{
@@ -537,6 +652,42 @@ func TestDivideResult(t *testing.T) {
 					"010": 4,
 					"100": 1,
 					"110": 64,
+					"111": 8,
+				},
+			},
+			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
+				return assert.NoError(t, err)
+			},
+		},
+		{
+			name: "Positive test - 2 circuits - swap virtual and physical qubits with larger and non-sequential mapping ",
+			args: args{
+				jd: &core.JobData{Result: &core.Result{
+					Counts:         core.Counts{"0001": 1, "0100": 2, "1000": 4, "1111": 8, "0010": 16, "0110": 32, "1011": 64},
+					TranspilerInfo: &core.TranspilerInfo{VirtualPhysicalMapping: core.VirtualPhysicalMapping{0: 1, 1: 4, 4: 2, 2: 3, 3: 0}}, // longer and non-sequential
+				}},
+				combinedQubitsList: []int32{3, 1},
+			},
+			wantCounts: core.Counts{
+				"1000": 1,
+				"0100": 2,
+				"0010": 4,
+				"1111": 8,
+				"0001": 16,
+				"0101": 32,
+				"1011": 64,
+			},
+			wantDividedCounts: core.DividedResult{
+				0: {
+					"0": 7,
+					"1": 120,
+				},
+				1: {
+					"000": 16,
+					"001": 4,
+					"010": 34,
+					"100": 1,
+					"101": 64,
 					"111": 8,
 				},
 			},
@@ -686,7 +837,7 @@ func TestDivideResult(t *testing.T) {
 			},
 			wantDividedCounts: nil,
 			assertion: func(t assert.TestingT, err error, i ...interface{}) bool {
-				return assert.EqualError(t, err, "bit string length of the counts is not equal to the length of virtualPhysicalMapping")
+				return assert.EqualError(t, err, "The length of the physical qubit list 3 is not equal to the length of the input bit string 4")
 			},
 		},
 		{


### PR DESCRIPTION
- fix: #8 
  - Fixed a bug that can't divide the result when the number of virutal_physical_mapping is not sequential like {0:0, 1:10}.
  - Add a process for the case where the length of classical bits (measured bits) is less than the circuit's qubits.