### PR TITLE
update CMD in Dockerfile.dev

### DIFF
--- a/coreapp/Dockerfile.dev
+++ b/coreapp/Dockerfile.dev
@@ -25,4 +25,4 @@ COPY . /app
 RUN go build -o /go/bin/edge ./cmd/edge/main.go
 
 # run application
-CMD ["edge", "poller", "--qpu=qmt", "--log-level=debug", "--transpiler=grpc", "--disable-stdout-log", "--enable-file-log"]
+CMD ["edge", "poller", "--qpu=qmt", "--db=service", "--transpiler=tranqu", "--log-level=debug", "--enable-file-log", "--log-dir=logs", "--dev-mode", "--setting-path=./setting/setting.toml", "--device-setting-path=./setting/device_setting.toml"]


### PR DESCRIPTION
Chang the `CMD` in `Dockerfile.dev` to match what’s used in the actual environment.