### PR TITLE
Allow configurable protocol (http/https) for API endpoints

### DIFF
--- a/coreapp/common/util.go
+++ b/coreapp/common/util.go
@@ -70,10 +70,6 @@ func (p SecuritySource) ApiKeyAuth(ctx context.Context, name string) (api.ApiKey
 // It uses the SecuritySource for authentication.
 func NewAPIClient(endpoint, apiKey string) (*api.Client, error) {
 	ss := SecuritySource{apiKey: apiKey}
-	// Ensure the endpoint starts with https://
-	if !strings.HasPrefix(endpoint, "https://") && !strings.HasPrefix(endpoint, "http://") {
-		endpoint = "https://" + endpoint
-	}
 	cli, err := api.NewClient(endpoint, ss)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to create a new API client/endpoint:%s/reason:%s", endpoint, err))

--- a/coreapp/db/service.go
+++ b/coreapp/db/service.go
@@ -41,7 +41,7 @@ func (s *ServiceDB) Setup(dbc core.DBChan, c *core.Conf) error {
 	s.apiKey = c.ServiceDBAPIKey
 	ss := dbSecuritySource{apiKey: s.apiKey}
 
-	cli, err := api.NewClient("https://"+s.endpoint, ss)
+	cli, err := api.NewClient(s.endpoint, ss)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to create a client/reason:%s", err))
 		return err

--- a/coreapp/poller/awspollclient.go
+++ b/coreapp/poller/awspollclient.go
@@ -52,7 +52,7 @@ func (p pollerSecuritySource) ApiKeyAuth(ctx context.Context, name api.Operation
 
 func newAWSPollClient(p *awsPollClientParams) (*awsPollClient, error) {
 	pss := pollerSecuritySource{apiKey: p.apiKey}
-	cli, err := api.NewClient("https://"+p.endPoint, pss)
+	cli, err := api.NewClient(p.endPoint, pss)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to create a client/reason:%s", err))
 		return nil, err
@@ -147,7 +147,7 @@ func toJobSlice(jobDefs []api.JobsJobDef) (jobs []core.Job, err error) {
 func (c *awsPollClient) downloadUserProgram(jobID string) (string, error) {
 	zap.L().Debug(fmt.Sprintf("requesting download userprogram to %s. EdgeName: %s, DeviceName: %s",
 		c.endpoint, c.edgeName, c.deviceName))
-	uri := fmt.Sprintf("https://%s/ssejobs/%s/download-src",
+	uri := fmt.Sprintf("%s/ssejobs/%s/download-src",
 		c.endpoint, jobID)
 
 	// FIXME

--- a/coreapp/qpu/gateway.go
+++ b/coreapp/qpu/gateway.go
@@ -36,9 +36,9 @@ func NewDefaultGatewayAgentSetting() DefaultGatewayAgentSetting {
 	return DefaultGatewayAgentSetting{
 		GatewayHost: "localhost",
 		GatewayPort: "50051",
-		APIEndpoint: "localhost",
-		APIKey:      "hogehoge",
-		DeviceId:    "hogehoge",
+		APIEndpoint: "https://localhost",
+		APIKey:      "your_api_key",
+		DeviceId:    "your_device_id",
 	}
 }
 

--- a/coreapp/setting/setting.sample.toml
+++ b/coreapp/setting/setting.sample.toml
@@ -9,7 +9,7 @@ estimator_host = "example.com"
       enable_test_mode = true
       edge = "polling_test_edge"
       device = "polling_test_device"
-      endpoint = "http://localhost:3001"
+      endpoint = "http://example.com:3001"
       normal_period = "500ms"
       idle_period = "500ms"
     [run_group.periodic_tasks.version_log]

--- a/coreapp/setting/setting.sample.toml
+++ b/coreapp/setting/setting.sample.toml
@@ -1,6 +1,6 @@
 [estimation]
 estimator_port = 502
-estimator_host = "hoge.com"
+estimator_host = "example.com"
 [run_group]
   [run_group.periodic_tasks]
     [run_group.periodic_tasks.poller]
@@ -9,7 +9,7 @@ estimator_host = "hoge.com"
       enable_test_mode = true
       edge = "polling_test_edge"
       device = "polling_test_device"
-      endpoint = "localhost:3001"
+      endpoint = "http://localhost:3001"
       normal_period = "500ms"
       idle_period = "500ms"
     [run_group.periodic_tasks.version_log]
@@ -38,6 +38,6 @@ estimator_host = "hoge.com"
   [com.gateway]
   gateway_host = "localhost"
   gateway_port = "50051"
-  api_endpoint = "hoge.com/v1"
+  api_endpoint = "https://example.com/v1"
   api_key = "secret_api_key"
   device_id = "your_device_id"

--- a/coreapp/sse/apiclient/apiclient.go
+++ b/coreapp/sse/apiclient/apiclient.go
@@ -78,7 +78,7 @@ func NewSseApiClient() (sseApiClient *SseApiClient, err error) {
 	}
 
 	ss := SecuritySource{apiKey: apiKey}
-	client, err := api.NewClient("https://"+endpoint, ss)
+	client, err := api.NewClient(endpoint, ss)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to make a client: %s", err))
 		return nil, err


### PR DESCRIPTION
Removes hardcoded "https://" prefix in API clients (sse/apiclient, db/service)
and updates sample config (setting.sample.toml).