### PR TITLE
Use RFC3339 for time parsing in gateway

### DIFF
--- a/coreapp/db/service.go
+++ b/coreapp/db/service.go
@@ -76,8 +76,14 @@ func (s *ServiceDB) Update(j core.Job) error {
 	jd := j.JobData()
 	jid := jd.ID
 	cJob := oas.ConvertToCloudJob(jd)
-	zap.L().Debug(fmt.Sprintf("Updating %s/status:%s/Transpiler:%v",
-		jid, cJob.Status, jd.Transpiler))
+	var transpilerOptions string
+	if jd.Transpiler != nil && jd.Transpiler.TranspilerOptions != nil {
+		transpilerOptions = string(jd.Transpiler.TranspilerOptions)
+	} else {
+		transpilerOptions = "<nil>" // nil is not marshaled
+	}
+	zap.L().Debug(fmt.Sprintf("Updating %s/status:%s/TranspilerOptions:%s",
+		jid, cJob.Status, transpilerOptions))
 	ctx := context.Background()
 	//TODO: fix this ad hoc impl
 	if !j.JobData().UseJobInfoUpdate {

--- a/coreapp/qpu/gateway.go
+++ b/coreapp/qpu/gateway.go
@@ -147,6 +147,8 @@ func (q *DefaultGatewayAgent) CallJob(j core.Job) error {
 		qasmToBeSent = j.JobData().TranspiledQASM
 	}
 
+	zap.L().Debug(fmt.Sprintf("Sending a job to QPU/"+
+		"JobID:%s, Shots:%d,QASM:%s", j.JobData().ID, j.JobData().Shots, qasmToBeSent))
 	startTime := time.Now()
 	resp, err := q.gatewayClient.CallJob(q.ctx, &qint.CallJobRequest{
 		JobId:   j.JobData().ID,

--- a/coreapp/qpu/gateway.go
+++ b/coreapp/qpu/gateway.go
@@ -85,7 +85,7 @@ func (q *DefaultGatewayAgent) Setup() (err error) {
 		return err
 	}
 	q.gatewayAddress = address
-	apiClient, err := common.NewAPIClient(q.setting.APIEndpoint, q.setting.APIKey) // Use common.NewAPIClient
+	apiClient, err := common.NewAPIClient(q.setting.APIEndpoint, q.setting.APIKey)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to create a new API client/reason:%s", err))
 	}
@@ -248,7 +248,7 @@ func (q *DefaultGatewayAgent) updateDeviceStatus(st core.DeviceStatus) error {
 }
 
 func (q *DefaultGatewayAgent) updateDeviceInfo(di *core.DeviceInfo) error {
-	caStr, err := strToTime(di.CalibratedAt)
+	caStr, err := parseRFC3339Time(di.CalibratedAt)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to parse time %s/reason:%s", di.CalibratedAt, err))
 		return err
@@ -284,10 +284,11 @@ func toDeviceDeviceStatusUpdateStatus(ds core.DeviceStatus) api.DevicesDeviceSta
 	}
 }
 
-func strToTime(t string) (time.Time, error) {
-	tt, err := time.Parse("2006-01-02 15:04:05.999999", t)
+// parseRFC3339Time parses a time string in RFC 3339 format (which is a profile of ISO 8601).
+func parseRFC3339Time(t string) (time.Time, error) {
+	tt, err := time.Parse(time.RFC3339, t)
 	if err != nil {
-		zap.L().Error(fmt.Sprintf("failed to parse time %s/reason:%s", t, err))
+		zap.L().Error(fmt.Sprintf("failed to parse time %s using RFC3339/reason:%s", t, err))
 		return time.Time{}, err
 	}
 	return tt, nil

--- a/coreapp/qpu/gateway_test.go
+++ b/coreapp/qpu/gateway_test.go
@@ -1,0 +1,77 @@
+package qpu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseRFC3339Time(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  time.Time
+		expectErr bool
+	}{
+		{
+			name:      "Valid RFC3339 format (UTC)",
+			input:     "2023-10-26T10:00:00Z",
+			expected:  time.Date(2023, 10, 26, 10, 0, 0, 0, time.UTC),
+			expectErr: false,
+		},
+		{
+			name:  "Valid RFC3339 format with timezone offset (+09:00)",
+			input: "2023-10-26T19:00:00+09:00",
+			// Expected time should be normalized to UTC or compared with the same timezone
+			expected:  time.Date(2023, 10, 26, 19, 0, 0, 0, time.FixedZone("JST", 9*60*60)),
+			expectErr: false,
+		},
+		{
+			name:      "Valid RFC3339 format with milliseconds (UTC)",
+			input:     "2023-10-26T10:00:00.123Z",
+			expected:  time.Date(2023, 10, 26, 10, 0, 0, 123000000, time.UTC),
+			expectErr: false,
+		},
+		{
+			name:      "Valid RFC3339 format with nanoseconds and timezone offset",
+			input:     "2024-04-09T13:40:00.123456789+09:00",
+			expected:  time.Date(2024, 4, 9, 13, 40, 0, 123456789, time.FixedZone("JST", 9*60*60)),
+			expectErr: false,
+		},
+		{
+			name:      "Invalid format - wrong separator",
+			input:     "2023-10-26 10:00:00Z",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid format - missing T",
+			input:     "2023-10-2610:00:00Z",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid format - incomplete date",
+			input:     "2023-10T10:00:00Z",
+			expectErr: true,
+		},
+		{
+			name:      "Invalid format - empty string",
+			input:     "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseRFC3339Time(tt.input)
+
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				// Compare time values ensuring they are in the same location for accurate comparison
+				assert.True(t, tt.expected.Equal(actual), "Expected %v, but got %v", tt.expected, actual)
+			}
+		})
+	}
+}

--- a/coreapp/setting/setting.sample.toml
+++ b/coreapp/setting/setting.sample.toml
@@ -18,13 +18,7 @@ estimator_host = "example.com"
     period = "10s"
       [run_group.periodic_tasks.metrics_log.params]
       file_dir = "/shares/metrics"
-  [run_group.internal_job_servers]
-    [run_group.internal_job_servers.multi_auto_server]
-  [run_group.api_servers]
-    [run_group.api_servers.cloud_mock]
-      [run_group.api_servers.cloud_mock.params]
-      host = "0.0.0.0"
-      port = 3000
+
 [com]
   [com.tranqu]
   host = "localhost"

--- a/coreapp/transpiler/tranqu.go
+++ b/coreapp/transpiler/tranqu.go
@@ -171,7 +171,8 @@ func toVirtualPhysicalMappingFromString(virtualPhysicalMapping string) (core.Vir
 		return core.VirtualPhysicalMappingRaw{}, err
 	}
 	vpm := core.VirtualPhysicalMappingRaw(d)
-	zap.L().Debug(fmt.Sprintf("converted virtual physical mapping:%v", vpm))
+	// Log the mapping as a string instead of potentially base64 encoded bytes
+	zap.L().Debug(fmt.Sprintf("converted virtual physical mapping:%s", string(vpm)))
 	return vpm, nil
 }
 

--- a/coreapp/transpiler/tranqu.go
+++ b/coreapp/transpiler/tranqu.go
@@ -163,7 +163,7 @@ func toVirtualPhysicalMappingFromString(virtualPhysicalMapping string) (core.Vir
 			virtualPhysicalMapping, err))
 		return core.VirtualPhysicalMappingRaw{}, err
 	}
-	zap.L().Debug(fmt.Sprintf("unmarshaled virtualPhysicalMapping:%v", m))
+	zap.L().Debug("Successfully unmarshaled virtualPhysicalMapping", zap.Any("qubit_mapping", m.QubitMapping), zap.Any("bit_mapping", m.BitMapping))
 	d, err := json.Marshal(m.QubitMapping)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to marshal qubit mapping:%v/reason:%s",
@@ -184,7 +184,7 @@ func toPhysicalVirtualMappingFromString(virtualPhysicalMapping string) (core.Phy
 			virtualPhysicalMapping, err))
 		return core.PhysicalVirtualMapping{}, err
 	}
-	zap.L().Debug(fmt.Sprintf("unmarshaled virtualPhysicalMapping:%v", m))
+	zap.L().Debug("Successfully unmarshaled virtualPhysicalMapping", zap.Any("qubit_mapping", m.QubitMapping), zap.Any("bit_mapping", m.BitMapping))
 	pvm := core.PhysicalVirtualMapping{}
 	for k, v := range m.QubitMapping {
 		num, err := strconv.ParseUint(k, 10, 32)


### PR DESCRIPTION
- Modify time parsing in `gateway.go` to use `time.RFC3339` (ISO 8601 profile) for `calibratedAt`.
- Rename `strToTime` function to `parseRFC3339Time` for better clarity.
- Add a comment indicating the use of RFC 3339 / ISO 8601.
- Create `gateway_test.go` and add unit tests for `parseRFC3339Time`.
- And some log things


