### PR TITLE
Add Support for Updating n_qubits Property in Device API

### DIFF
--- a/coreapp/common/util.go
+++ b/coreapp/common/util.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	api "github.com/oqtopus-team/oqtopus-engine/coreapp/oas/gen/providerapi" // Added import for api package
+	api "github.com/oqtopus-team/oqtopus-engine/coreapp/oas/gen/providerapi"
 )
 
 func GetAssetAbsPath(fileName string) (string, error) {
@@ -66,10 +66,17 @@ func (p SecuritySource) ApiKeyAuth(ctx context.Context, name string) (api.ApiKey
 	return apiKeyAuth, nil
 }
 
+// NewSecuritySource creates a new SecuritySource instance.
+// This constructor is needed because the apiKey field is unexported.
+func NewSecuritySource(apiKey string) SecuritySource {
+	return SecuritySource{apiKey: apiKey}
+}
+
 // NewAPIClient creates a new OpenAPI client with the given endpoint and API key.
 // It uses the SecuritySource for authentication.
 func NewAPIClient(endpoint, apiKey string) (*api.Client, error) {
 	ss := SecuritySource{apiKey: apiKey}
+	// Use the default http.Client via ogen's default behavior
 	cli, err := api.NewClient(endpoint, ss)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to create a new API client/endpoint:%s/reason:%s", endpoint, err))

--- a/coreapp/db/service.go
+++ b/coreapp/db/service.go
@@ -177,7 +177,7 @@ func (s *ServiceDB) Update(j core.Job) error {
 					Message:         api.NewOptNilString(cJob.JobInfo.Message.Value),
 				}),
 		})
-	vpmStr := j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw.String()
+	vpmStr := string(j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw)
 	zap.L().Debug(fmt.Sprintf(
 		"JobsUpdateJobInfoRequest/JobID:%s/Status:%s/Message:%s/StatsRaw:%v/TranspiledQASM:%s/VirtualPhysicalMappingDecoded:%s",
 		jid, cJob.Status, cJob.JobInfo.Message.Value, stats, j.JobData().TranspiledQASM,

--- a/coreapp/db/service.go
+++ b/coreapp/db/service.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"reflect"
 
@@ -178,14 +177,7 @@ func (s *ServiceDB) Update(j core.Job) error {
 					Message:         api.NewOptNilString(cJob.JobInfo.Message.Value),
 				}),
 		})
-	vpmRaw := j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw.String()
-	decodedVPM, err := base64.StdEncoding.DecodeString(vpmRaw)
-	vpmStr := ""
-	if err != nil {
-		vpmStr = fmt.Sprintf("base64_decode_error(%s): %s", err, vpmRaw)
-	} else {
-		vpmStr = string(decodedVPM)
-	}
+	vpmStr := j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw.String()
 	zap.L().Debug(fmt.Sprintf(
 		"JobsUpdateJobInfoRequest/JobID:%s/Status:%s/Message:%s/StatsRaw:%v/TranspiledQASM:%s/VirtualPhysicalMappingDecoded:%s",
 		jid, cJob.Status, cJob.JobInfo.Message.Value, stats, j.JobData().TranspiledQASM,

--- a/coreapp/estimation/job.go
+++ b/coreapp/estimation/job.go
@@ -318,7 +318,14 @@ func estimationPreProcess(j *EstimationJob) (preprocessedQASMs []string, grouped
 		mappingList = append(mappingList, mapping[key])
 	}
 	zap.L().Debug(fmt.Sprintf("mappingList:%v", mappingList))
-	zap.L().Debug(fmt.Sprintf("VirtualPhysicalMapping:%s", j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw))
+	// Log VirtualPhysicalMapping as a map for better readability
+	vpMapping, vpErr := j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw.ToMap()
+	if vpErr != nil {
+		zap.L().Warn(fmt.Sprintf("Failed to convert VirtualPhysicalMappingRaw to map for logging: %v", vpErr))
+		zap.L().Debug(fmt.Sprintf("VirtualPhysicalMapping (raw):%s", j.JobData().Result.TranspilerInfo.VirtualPhysicalMappingRaw)) // fallback to raw output
+	} else {
+		zap.L().Debug(fmt.Sprintf("VirtualPhysicalMapping:%v", vpMapping))
+	}
 	zap.L().Debug(fmt.Sprintf("default basis gates:%v", j.setting.BasisGates))
 	req := &pb.ReqEstimationPreProcessRequest{
 		QasmCode:    j.usedQASM,

--- a/coreapp/oas/gen/mock_providerapi/oas_client_gen_mock.go
+++ b/coreapp/oas/gen/mock_providerapi/oas_client_gen_mock.go
@@ -80,6 +80,21 @@ func (mr *MockInvokerMockRecorder) GetSsesrc(ctx, params interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSsesrc", reflect.TypeOf((*MockInvoker)(nil).GetSsesrc), ctx, params)
 }
 
+// PatchDevice mocks base method.
+func (m *MockInvoker) PatchDevice(ctx context.Context, request providerapi.OptDevicesUpdateDeviceRequest, params providerapi.PatchDeviceParams) (providerapi.PatchDeviceRes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchDevice", ctx, request, params)
+	ret0, _ := ret[0].(providerapi.PatchDeviceRes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchDevice indicates an expected call of PatchDevice.
+func (mr *MockInvokerMockRecorder) PatchDevice(ctx, request, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDevice", reflect.TypeOf((*MockInvoker)(nil).PatchDevice), ctx, request, params)
+}
+
 // PatchDeviceInfo mocks base method.
 func (m *MockInvoker) PatchDeviceInfo(ctx context.Context, request providerapi.OptDevicesDeviceInfoUpdate, params providerapi.PatchDeviceInfoParams) (providerapi.PatchDeviceInfoRes, error) {
 	m.ctrl.T.Helper()

--- a/coreapp/oas/gen/providerapi/oas_defaults_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_defaults_gen.go
@@ -11,6 +11,14 @@ func (s *DevicesDeviceDataUpdateResponse) setDefaults() {
 }
 
 // setDefaults set default value of fields.
+func (s *DevicesUpdateDeviceResponse) setDefaults() {
+	{
+		val := string("Device is successfully updated.")
+		s.Message = val
+	}
+}
+
+// setDefaults set default value of fields.
 func (s *JobsJobDef) setDefaults() {
 	{
 		s.ExecutionTime.Null = true

--- a/coreapp/oas/gen/providerapi/oas_handlers_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_handlers_gen.go
@@ -588,6 +588,203 @@ func (s *Server) handleGetSsesrcRequest(args [1]string, argsEscaped bool, w http
 	}
 }
 
+// handlePatchDeviceRequest handles patchDevice operation.
+//
+// Update a part of selected device's properties.
+//
+// PATCH /devices/{device_id}
+func (s *Server) handlePatchDeviceRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	statusWriter := &codeRecorder{ResponseWriter: w}
+	w = statusWriter
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("patchDevice"),
+		semconv.HTTPRequestMethodKey.String("PATCH"),
+		semconv.HTTPRouteKey.String("/devices/{device_id}"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), PatchDeviceOperation,
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Add Labeler to context.
+	labeler := &Labeler{attrs: otelAttrs}
+	ctx = contextWithLabeler(ctx, labeler)
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+
+		attrSet := labeler.AttributeSet()
+		attrs := attrSet.ToSlice()
+		code := statusWriter.status
+		if code != 0 {
+			codeAttr := semconv.HTTPResponseStatusCode(code)
+			attrs = append(attrs, codeAttr)
+			span.SetAttributes(codeAttr)
+		}
+		attrOpt := metric.WithAttributes(attrs...)
+
+		// Increment request counter.
+		s.requests.Add(ctx, 1, attrOpt)
+
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(elapsedDuration)/float64(time.Millisecond), attrOpt)
+	}()
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+
+			// https://opentelemetry.io/docs/specs/semconv/http/http-spans/#status
+			// Span Status MUST be left unset if HTTP status code was in the 1xx, 2xx or 3xx ranges,
+			// unless there was another error (e.g., network error receiving the response body; or 3xx codes with
+			// max redirects exceeded), in which case status MUST be set to Error.
+			code := statusWriter.status
+			if code >= 100 && code < 500 {
+				span.SetStatus(codes.Error, stage)
+			}
+
+			attrSet := labeler.AttributeSet()
+			attrs := attrSet.ToSlice()
+			if code != 0 {
+				attrs = append(attrs, semconv.HTTPResponseStatusCode(code))
+			}
+
+			s.errors.Add(ctx, 1, metric.WithAttributes(attrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: PatchDeviceOperation,
+			ID:   "patchDevice",
+		}
+	)
+	{
+		type bitset = [1]uint8
+		var satisfied bitset
+		{
+			sctx, ok, err := s.securityApiKeyAuth(ctx, PatchDeviceOperation, r)
+			if err != nil {
+				err = &ogenerrors.SecurityError{
+					OperationContext: opErrContext,
+					Security:         "ApiKeyAuth",
+					Err:              err,
+				}
+				defer recordError("Security:ApiKeyAuth", err)
+				s.cfg.ErrorHandler(ctx, w, r, err)
+				return
+			}
+			if ok {
+				satisfied[0] |= 1 << 0
+				ctx = sctx
+			}
+		}
+
+		if ok := func() bool {
+		nextRequirement:
+			for _, requirement := range []bitset{
+				{0b00000001},
+			} {
+				for i, mask := range requirement {
+					if satisfied[i]&mask != mask {
+						continue nextRequirement
+					}
+				}
+				return true
+			}
+			return false
+		}(); !ok {
+			err = &ogenerrors.SecurityError{
+				OperationContext: opErrContext,
+				Err:              ogenerrors.ErrSecurityRequirementIsNotSatisfied,
+			}
+			defer recordError("Security", err)
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+	}
+	params, err := decodePatchDeviceParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	request, close, err := s.decodePatchDeviceRequest(r)
+	if err != nil {
+		err = &ogenerrors.DecodeRequestError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		defer recordError("DecodeRequest", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+	defer func() {
+		if err := close(); err != nil {
+			recordError("CloseRequest", err)
+		}
+	}()
+
+	var response PatchDeviceRes
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    PatchDeviceOperation,
+			OperationSummary: "Update a part of selected device's properties.",
+			OperationID:      "patchDevice",
+			Body:             request,
+			Params: middleware.Parameters{
+				{
+					Name: "device_id",
+					In:   "path",
+				}: params.DeviceID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = OptDevicesUpdateDeviceRequest
+			Params   = PatchDeviceParams
+			Response = PatchDeviceRes
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackPatchDeviceParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.PatchDevice(ctx, request, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.PatchDevice(ctx, request, params)
+	}
+	if err != nil {
+		defer recordError("Internal", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	if err := encodePatchDeviceResponse(response, w, span); err != nil {
+		defer recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handlePatchDeviceInfoRequest handles patchDeviceInfo operation.
 //
 // Update device_info(calibration data) of selected device.

--- a/coreapp/oas/gen/providerapi/oas_interfaces_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_interfaces_gen.go
@@ -17,6 +17,10 @@ type PatchDeviceInfoRes interface {
 	patchDeviceInfoRes()
 }
 
+type PatchDeviceRes interface {
+	patchDeviceRes()
+}
+
 type PatchDeviceStatusRes interface {
 	patchDeviceStatusRes()
 }

--- a/coreapp/oas/gen/providerapi/oas_json_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_json_gen.go
@@ -357,6 +357,166 @@ func (s *DevicesDeviceStatusUpdateStatus) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *DevicesUpdateDeviceRequest) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DevicesUpdateDeviceRequest) encodeFields(e *jx.Encoder) {
+	{
+		if s.NQubits.Set {
+			e.FieldStart("n_qubits")
+			s.NQubits.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDevicesUpdateDeviceRequest = [1]string{
+	0: "n_qubits",
+}
+
+// Decode decodes DevicesUpdateDeviceRequest from json.
+func (s *DevicesUpdateDeviceRequest) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DevicesUpdateDeviceRequest to nil")
+	}
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "n_qubits":
+			if err := func() error {
+				s.NQubits.Reset()
+				if err := s.NQubits.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"n_qubits\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DevicesUpdateDeviceRequest")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DevicesUpdateDeviceRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DevicesUpdateDeviceRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DevicesUpdateDeviceResponse) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DevicesUpdateDeviceResponse) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("message")
+		e.Str(s.Message)
+	}
+}
+
+var jsonFieldsNameOfDevicesUpdateDeviceResponse = [1]string{
+	0: "message",
+}
+
+// Decode decodes DevicesUpdateDeviceResponse from json.
+func (s *DevicesUpdateDeviceResponse) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DevicesUpdateDeviceResponse to nil")
+	}
+	var requiredBitSet [1]uint8
+	s.setDefaults()
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "message":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				v, err := d.Str()
+				s.Message = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"message\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DevicesUpdateDeviceResponse")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDevicesUpdateDeviceResponse) {
+					name = jsonFieldsNameOfDevicesUpdateDeviceResponse[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DevicesUpdateDeviceResponse) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DevicesUpdateDeviceResponse) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *ErrorBadRequest) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -3472,6 +3632,39 @@ func (s *OptDevicesDeviceStatusUpdate) UnmarshalJSON(data []byte) error {
 	return s.Decode(d)
 }
 
+// Encode encodes DevicesUpdateDeviceRequest as json.
+func (o OptDevicesUpdateDeviceRequest) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	o.Value.Encode(e)
+}
+
+// Decode decodes DevicesUpdateDeviceRequest from json.
+func (o *OptDevicesUpdateDeviceRequest) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptDevicesUpdateDeviceRequest to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptDevicesUpdateDeviceRequest) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptDevicesUpdateDeviceRequest) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes float64 as json.
 func (o OptFloat64) Encode(e *jx.Encoder) {
 	if !o.Set {
@@ -3771,6 +3964,57 @@ func (s OptNilFloat64) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptNilFloat64) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes int as json.
+func (o OptNilInt) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	if o.Null {
+		e.Null()
+		return
+	}
+	e.Int(int(o.Value))
+}
+
+// Decode decodes int from json.
+func (o *OptNilInt) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptNilInt to nil")
+	}
+	if d.Next() == jx.Null {
+		if err := d.Null(); err != nil {
+			return err
+		}
+
+		var v int
+		o.Value = v
+		o.Set = true
+		o.Null = true
+		return nil
+	}
+	o.Set = true
+	o.Null = false
+	v, err := d.Int()
+	if err != nil {
+		return err
+	}
+	o.Value = int(v)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptNilInt) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptNilInt) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/coreapp/oas/gen/providerapi/oas_operations_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_operations_gen.go
@@ -9,6 +9,7 @@ const (
 	GetJobOperation                  OperationName = "GetJob"
 	GetJobsOperation                 OperationName = "GetJobs"
 	GetSsesrcOperation               OperationName = "GetSsesrc"
+	PatchDeviceOperation             OperationName = "PatchDevice"
 	PatchDeviceInfoOperation         OperationName = "PatchDeviceInfo"
 	PatchDeviceStatusOperation       OperationName = "PatchDeviceStatus"
 	PatchJobOperation                OperationName = "PatchJob"

--- a/coreapp/oas/gen/providerapi/oas_parameters_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_parameters_gen.go
@@ -376,6 +376,72 @@ func decodeGetSsesrcParams(args [1]string, argsEscaped bool, r *http.Request) (p
 	return params, nil
 }
 
+// PatchDeviceParams is parameters of patchDevice operation.
+type PatchDeviceParams struct {
+	// Device ID.
+	DeviceID string
+}
+
+func unpackPatchDeviceParams(packed middleware.Parameters) (params PatchDeviceParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "device_id",
+			In:   "path",
+		}
+		params.DeviceID = packed[key].(string)
+	}
+	return params
+}
+
+func decodePatchDeviceParams(args [1]string, argsEscaped bool, r *http.Request) (params PatchDeviceParams, _ error) {
+	// Decode path: device_id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "device_id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.DeviceID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "device_id",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // PatchDeviceInfoParams is parameters of patchDeviceInfo operation.
 type PatchDeviceInfoParams struct {
 	// Device ID.

--- a/coreapp/oas/gen/providerapi/oas_request_decoders_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_request_decoders_gen.go
@@ -17,6 +17,73 @@ import (
 	"github.com/ogen-go/ogen/validate"
 )
 
+func (s *Server) decodePatchDeviceRequest(r *http.Request) (
+	req OptDevicesUpdateDeviceRequest,
+	close func() error,
+	rerr error,
+) {
+	var closers []func() error
+	close = func() error {
+		var merr error
+		// Close in reverse order, to match defer behavior.
+		for i := len(closers) - 1; i >= 0; i-- {
+			c := closers[i]
+			merr = multierr.Append(merr, c())
+		}
+		return merr
+	}
+	defer func() {
+		if rerr != nil {
+			rerr = multierr.Append(rerr, close())
+		}
+	}()
+	if _, ok := r.Header["Content-Type"]; !ok && r.ContentLength == 0 {
+		return req, close, nil
+	}
+	ct, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return req, close, errors.Wrap(err, "parse media type")
+	}
+	switch {
+	case ct == "application/json":
+		if r.ContentLength == 0 {
+			return req, close, nil
+		}
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			return req, close, err
+		}
+
+		if len(buf) == 0 {
+			return req, close, nil
+		}
+
+		d := jx.DecodeBytes(buf)
+
+		var request OptDevicesUpdateDeviceRequest
+		if err := func() error {
+			request.Reset()
+			if err := request.Decode(d); err != nil {
+				return err
+			}
+			if err := d.Skip(); err != io.EOF {
+				return errors.New("unexpected trailing data")
+			}
+			return nil
+		}(); err != nil {
+			err = &ogenerrors.DecodeBodyError{
+				ContentType: ct,
+				Body:        buf,
+				Err:         err,
+			}
+			return req, close, err
+		}
+		return request, close, nil
+	default:
+		return req, close, validate.InvalidContentType(ct)
+	}
+}
+
 func (s *Server) decodePatchDeviceInfoRequest(r *http.Request) (
 	req OptDevicesDeviceInfoUpdate,
 	close func() error,

--- a/coreapp/oas/gen/providerapi/oas_request_encoders_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_request_encoders_gen.go
@@ -15,6 +15,26 @@ import (
 	"github.com/ogen-go/ogen/uri"
 )
 
+func encodePatchDeviceRequest(
+	req OptDevicesUpdateDeviceRequest,
+	r *http.Request,
+) error {
+	const contentType = "application/json"
+	if !req.Set {
+		// Keep request with empty body if value is not set.
+		return nil
+	}
+	e := new(jx.Encoder)
+	{
+		if req.Set {
+			req.Encode(e)
+		}
+	}
+	encoded := e.Bytes()
+	ht.SetBody(r, bytes.NewReader(encoded), contentType)
+	return nil
+}
+
 func encodePatchDeviceInfoRequest(
 	req OptDevicesDeviceInfoUpdate,
 	r *http.Request,

--- a/coreapp/oas/gen/providerapi/oas_response_decoders_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_response_decoders_gen.go
@@ -385,6 +385,152 @@ func decodeGetSsesrcResponse(resp *http.Response) (res GetSsesrcRes, _ error) {
 	return res, validate.UnexpectedStatusCode(resp.StatusCode)
 }
 
+func decodePatchDeviceResponse(resp *http.Response) (res PatchDeviceRes, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response DevicesUpdateDeviceResponse
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 400:
+		// Code 400.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ErrorBadRequest
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 404:
+		// Code 404.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ErrorNotFoundError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response ErrorInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	return res, validate.UnexpectedStatusCode(resp.StatusCode)
+}
+
 func decodePatchDeviceInfoResponse(resp *http.Response) (res PatchDeviceInfoRes, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/coreapp/oas/gen/providerapi/oas_response_encoders_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_response_encoders_gen.go
@@ -162,6 +162,65 @@ func encodeGetSsesrcResponse(response GetSsesrcRes, w http.ResponseWriter, span 
 	}
 }
 
+func encodePatchDeviceResponse(response PatchDeviceRes, w http.ResponseWriter, span trace.Span) error {
+	switch response := response.(type) {
+	case *DevicesUpdateDeviceResponse:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(200)
+		span.SetStatus(codes.Ok, http.StatusText(200))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ErrorBadRequest:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(400)
+		span.SetStatus(codes.Error, http.StatusText(400))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ErrorNotFoundError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(404)
+		span.SetStatus(codes.Error, http.StatusText(404))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *ErrorInternalServerError:
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	default:
+		return errors.Errorf("unexpected response type: %T", response)
+	}
+}
+
 func encodePatchDeviceInfoResponse(response PatchDeviceInfoRes, w http.ResponseWriter, span trace.Span) error {
 	switch response := response.(type) {
 	case *DevicesDeviceDataUpdateResponse:

--- a/coreapp/oas/gen/providerapi/oas_router_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_router_gen.go
@@ -79,7 +79,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				elem = elem[idx:]
 
 				if len(elem) == 0 {
-					break
+					switch r.Method {
+					case "PATCH":
+						s.handlePatchDeviceRequest([1]string{
+							args[0],
+						}, elemIsEscaped, w, r)
+					default:
+						s.notAllowed(w, r, "PATCH")
+					}
+
+					return
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"
@@ -474,7 +483,18 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 				elem = elem[idx:]
 
 				if len(elem) == 0 {
-					break
+					switch method {
+					case "PATCH":
+						r.name = PatchDeviceOperation
+						r.summary = "Update a part of selected device's properties."
+						r.operationID = "patchDevice"
+						r.pathPattern = "/devices/{device_id}"
+						r.args = args
+						r.count = 1
+						return r, true
+					default:
+						return
+					}
 				}
 				switch elem[0] {
 				case '/': // Prefix: "/"

--- a/coreapp/oas/gen/providerapi/oas_schemas_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_schemas_gen.go
@@ -128,6 +128,38 @@ func (s *DevicesDeviceStatusUpdateStatus) UnmarshalText(data []byte) error {
 	}
 }
 
+// Ref: #/components/schemas/devices.UpdateDeviceRequest
+type DevicesUpdateDeviceRequest struct {
+	NQubits OptNilInt `json:"n_qubits"`
+}
+
+// GetNQubits returns the value of NQubits.
+func (s *DevicesUpdateDeviceRequest) GetNQubits() OptNilInt {
+	return s.NQubits
+}
+
+// SetNQubits sets the value of NQubits.
+func (s *DevicesUpdateDeviceRequest) SetNQubits(val OptNilInt) {
+	s.NQubits = val
+}
+
+// Ref: #/components/schemas/devices.UpdateDeviceResponse
+type DevicesUpdateDeviceResponse struct {
+	Message string `json:"message"`
+}
+
+// GetMessage returns the value of Message.
+func (s *DevicesUpdateDeviceResponse) GetMessage() string {
+	return s.Message
+}
+
+// SetMessage sets the value of Message.
+func (s *DevicesUpdateDeviceResponse) SetMessage(val string) {
+	s.Message = val
+}
+
+func (*DevicesUpdateDeviceResponse) patchDeviceRes() {}
+
 // Ref: #/components/schemas/error.BadRequest
 type ErrorBadRequest struct {
 	Message string `json:"message"`
@@ -147,6 +179,7 @@ func (*ErrorBadRequest) getJobRes()                  {}
 func (*ErrorBadRequest) getJobsRes()                 {}
 func (*ErrorBadRequest) getSsesrcRes()               {}
 func (*ErrorBadRequest) patchDeviceInfoRes()         {}
+func (*ErrorBadRequest) patchDeviceRes()             {}
 func (*ErrorBadRequest) patchDeviceStatusRes()       {}
 func (*ErrorBadRequest) patchJobInfoRes()            {}
 func (*ErrorBadRequest) patchSselogRes()             {}
@@ -187,6 +220,7 @@ func (s *ErrorInternalServerError) SetMessage(val string) {
 func (*ErrorInternalServerError) getJobsRes()           {}
 func (*ErrorInternalServerError) getSsesrcRes()         {}
 func (*ErrorInternalServerError) patchDeviceInfoRes()   {}
+func (*ErrorInternalServerError) patchDeviceRes()       {}
 func (*ErrorInternalServerError) patchDeviceStatusRes() {}
 func (*ErrorInternalServerError) patchSselogRes()       {}
 
@@ -208,6 +242,7 @@ func (s *ErrorNotFoundError) SetMessage(val string) {
 func (*ErrorNotFoundError) getJobRes()                  {}
 func (*ErrorNotFoundError) getSsesrcRes()               {}
 func (*ErrorNotFoundError) patchDeviceInfoRes()         {}
+func (*ErrorNotFoundError) patchDeviceRes()             {}
 func (*ErrorNotFoundError) patchDeviceStatusRes()       {}
 func (*ErrorNotFoundError) patchJobInfoRes()            {}
 func (*ErrorNotFoundError) patchJobRes()                {}
@@ -1326,6 +1361,52 @@ func (o OptDevicesDeviceStatusUpdate) Or(d DevicesDeviceStatusUpdate) DevicesDev
 	return d
 }
 
+// NewOptDevicesUpdateDeviceRequest returns new OptDevicesUpdateDeviceRequest with value set to v.
+func NewOptDevicesUpdateDeviceRequest(v DevicesUpdateDeviceRequest) OptDevicesUpdateDeviceRequest {
+	return OptDevicesUpdateDeviceRequest{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptDevicesUpdateDeviceRequest is optional DevicesUpdateDeviceRequest.
+type OptDevicesUpdateDeviceRequest struct {
+	Value DevicesUpdateDeviceRequest
+	Set   bool
+}
+
+// IsSet returns true if OptDevicesUpdateDeviceRequest was set.
+func (o OptDevicesUpdateDeviceRequest) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptDevicesUpdateDeviceRequest) Reset() {
+	var v DevicesUpdateDeviceRequest
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptDevicesUpdateDeviceRequest) SetTo(v DevicesUpdateDeviceRequest) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptDevicesUpdateDeviceRequest) Get() (v DevicesUpdateDeviceRequest, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptDevicesUpdateDeviceRequest) Or(d DevicesUpdateDeviceRequest) DevicesUpdateDeviceRequest {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
 // NewOptFloat64 returns new OptFloat64 with value set to v.
 func NewOptFloat64(v float64) OptFloat64 {
 	return OptFloat64{
@@ -1814,6 +1895,69 @@ func (o OptNilFloat64) Get() (v float64, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptNilFloat64) Or(d float64) float64 {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptNilInt returns new OptNilInt with value set to v.
+func NewOptNilInt(v int) OptNilInt {
+	return OptNilInt{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptNilInt is optional nullable int.
+type OptNilInt struct {
+	Value int
+	Set   bool
+	Null  bool
+}
+
+// IsSet returns true if OptNilInt was set.
+func (o OptNilInt) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptNilInt) Reset() {
+	var v int
+	o.Value = v
+	o.Set = false
+	o.Null = false
+}
+
+// SetTo sets value to v.
+func (o *OptNilInt) SetTo(v int) {
+	o.Set = true
+	o.Null = false
+	o.Value = v
+}
+
+// IsSet returns true if value is Null.
+func (o OptNilInt) IsNull() bool { return o.Null }
+
+// SetNull sets value to null.
+func (o *OptNilInt) SetToNull() {
+	o.Set = true
+	o.Null = true
+	var v int
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptNilInt) Get() (v int, ok bool) {
+	if o.Null {
+		return v, false
+	}
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptNilInt) Or(d int) int {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/coreapp/oas/gen/providerapi/oas_server_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_server_gen.go
@@ -26,6 +26,12 @@ type Handler interface {
 	//
 	// GET /jobs/{job_id}/ssesrc
 	GetSsesrc(ctx context.Context, params GetSsesrcParams) (GetSsesrcRes, error)
+	// PatchDevice implements patchDevice operation.
+	//
+	// Update a part of selected device's properties.
+	//
+	// PATCH /devices/{device_id}
+	PatchDevice(ctx context.Context, req OptDevicesUpdateDeviceRequest, params PatchDeviceParams) (PatchDeviceRes, error)
 	// PatchDeviceInfo implements patchDeviceInfo operation.
 	//
 	// Update device_info(calibration data) of selected device.

--- a/coreapp/oas/gen/providerapi/oas_unimplemented_gen.go
+++ b/coreapp/oas/gen/providerapi/oas_unimplemented_gen.go
@@ -40,6 +40,15 @@ func (UnimplementedHandler) GetSsesrc(ctx context.Context, params GetSsesrcParam
 	return r, ht.ErrNotImplemented
 }
 
+// PatchDevice implements patchDevice operation.
+//
+// Update a part of selected device's properties.
+//
+// PATCH /devices/{device_id}
+func (UnimplementedHandler) PatchDevice(ctx context.Context, req OptDevicesUpdateDeviceRequest, params PatchDeviceParams) (r PatchDeviceRes, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // PatchDeviceInfo implements patchDeviceInfo operation.
 //
 // Update device_info(calibration data) of selected device.

--- a/coreapp/oas/provider/openapi.yaml
+++ b/coreapp/oas/provider/openapi.yaml
@@ -15,6 +15,62 @@ servers:
 security:
   - ApiKeyAuth: []
 paths:
+  /devices/{device_id}:
+    patch:
+      tags:
+        - devices
+      summary: Update a part of selected device's properties.
+      description: Update a part of selected device's properties.
+      operationId: patchDevice
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: device_id
+          description: Device ID
+          required: true
+          schema:
+            type: string
+            example: Kawasaki
+      requestBody:
+        description: Chagens to the specified device.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/devices.UpdateDeviceRequest'
+      responses:
+        '200':
+          description: Device is updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/devices.UpdateDeviceResponse'
+              example:
+                message: Device is successfully updated
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.BadRequest'
+              example:
+                message: Bad request malformed input data
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.NotFoundError'
+              example:
+                message: Device not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error.InternalServerError'
+              example:
+                message: Internal server error
   /devices/{device_id}/status:
     patch:
       tags:
@@ -466,25 +522,20 @@ components:
       in: header
       name: X-Api-Key
   schemas:
-    devices.DeviceStatusUpdate:
+    devices.UpdateDeviceRequest:
       type: object
       properties:
-        status:
-          type: string
-          enum:
-            - available
-            - unavailable
-          nullable: false
-      required:
-        - status
-    devices.DeviceDataUpdateResponse:
+        n_qubits:
+          type: integer
+          nullable: true
+    devices.UpdateDeviceResponse:
       type: object
       properties:
         message:
           type: string
           nullable: false
-          default: Device's data updated
-          example: Device's data updated
+          default: Device is successfully updated.
+          example: Device is successfully updated.
       required:
         - message
     error.BadRequest:
@@ -509,6 +560,27 @@ components:
         message:
           type: string
           nullable: false
+      required:
+        - message
+    devices.DeviceStatusUpdate:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - available
+            - unavailable
+          nullable: false
+      required:
+        - status
+    devices.DeviceDataUpdateResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          nullable: false
+          default: Device's data updated
+          example: Device's data updated
       required:
         - message
     devices.DeviceInfoUpdate:

--- a/coreapp/oas/provider/paths/devices.yaml
+++ b/coreapp/oas/provider/paths/devices.yaml
@@ -1,3 +1,60 @@
+devices.device:
+    patch:
+      tags:
+        - devices
+      summary: "Update a part of selected device's properties."
+      description: "Update a part of selected device's properties."
+      operationId: patchDevice
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: device_id
+          description: "Device ID"
+          required: true
+          schema:
+            type: string
+            example: "Kawasaki"
+      requestBody:
+        description: "Chagens to the specified device."
+        content:
+          application/json:
+            schema:
+              $ref: "../schemas/devices.yaml#/devices.UpdateDeviceRequest"
+      responses:
+        '200':
+          description: Device is updated
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/devices.yaml#/devices.UpdateDeviceResponse'
+              example:
+                message: Device is successfully updated
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/error.yaml#/error.BadRequest'
+              example:
+                message: Bad request malformed input data
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/error.yaml#/error.NotFoundError'
+              example:
+                message: Device not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '../schemas/error.yaml#/error.InternalServerError'
+              example:
+                message: Internal server error
+
 devices.device_status:
     patch:
       tags:

--- a/coreapp/oas/provider/root.yaml
+++ b/coreapp/oas/provider/root.yaml
@@ -15,6 +15,8 @@ servers:
 security:
   - ApiKeyAuth: []
 paths:
+  /devices/{device_id}:
+    $ref: ./paths/devices.yaml#/devices.device
   /devices/{device_id}/status:
     $ref: ./paths/devices.yaml#/devices.device_status
   /devices/{device_id}/device_info:

--- a/coreapp/oas/provider/schemas/devices.yaml
+++ b/coreapp/oas/provider/schemas/devices.yaml
@@ -1,3 +1,22 @@
+devices.UpdateDeviceRequest:
+  type: object
+  properties:
+    n_qubits:
+      type: integer
+      nullable: true
+
+devices.UpdateDeviceResponse:
+  type: object
+  properties:
+    message:
+      type: string
+      nullable: false
+      default: Device is successfully updated.
+      example: Device is successfully updated.
+  required:
+    - message
+
+
 devices.DeviceDataUpdateResponse:
   type: object
   properties:

--- a/coreapp/qpu/gateway.go
+++ b/coreapp/qpu/gateway.go
@@ -289,7 +289,7 @@ func (q *DefaultGatewayAgent) updateDevice(di *core.DeviceInfo) error {
 	params := api.PatchDeviceParams{
 		DeviceID: q.setting.DeviceId,
 	}
-	zap.L().Debug(fmt.Sprintf("device update to %s", di))
+	zap.L().Debug(fmt.Sprintf("MaxQubits update to %d", di.MaxQubits))
 	res, err := q.apiClient.PatchDevice(context.TODO(), req, params)
 	if err != nil {
 		zap.L().Error(fmt.Sprintf("failed to update device/reason:%s", err))

--- a/coreapp/qpu/gateway_test.go
+++ b/coreapp/qpu/gateway_test.go
@@ -1,9 +1,13 @@
+//go:build unit
+// +build unit
+
 package qpu
 
 import (
 	"testing"
 	"time"
 
+	"github.com/oqtopus-team/oqtopus-engine/coreapp/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,6 +76,47 @@ func TestParseRFC3339Time(t *testing.T) {
 				// Compare time values ensuring they are in the same location for accurate comparison
 				assert.True(t, tt.expected.Equal(actual), "Expected %v, but got %v", tt.expected, actual)
 			}
+		})
+	}
+}
+
+func Test_hasDeviceChanged(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldDI    *core.DeviceInfo
+		newDI    *core.DeviceInfo
+		expected bool
+	}{
+		{
+			name:     "Old device info is nil",
+			oldDI:    nil,
+			newDI:    &core.DeviceInfo{MaxQubits: 5},
+			expected: true,
+		},
+		{
+			name:     "New device info is nil",
+			oldDI:    &core.DeviceInfo{MaxQubits: 5},
+			newDI:    nil,
+			expected: true,
+		},
+		{
+			name:     "MaxQubits is changed",
+			oldDI:    &core.DeviceInfo{MaxQubits: 5},
+			newDI:    &core.DeviceInfo{MaxQubits: 10},
+			expected: true,
+		},
+		{
+			name:     "MaxQubits is not changed",
+			oldDI:    &core.DeviceInfo{MaxQubits: 5},
+			newDI:    &core.DeviceInfo{MaxQubits: 5},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasDeviceChanged(tt.oldDI, tt.newDI)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
It introduces updates and enhancements to the Device API. However, the API currently only supports updating the n_qubits property of devices. 
 - Key changes include:  
   - Added support for updating the n_qubits property via the Device API.
   - Updated OpenAPI specifications (openapi.yaml) to reflect the changes.
